### PR TITLE
Create Dissenter_Opens_In_Frame.js

### DIFF
--- a/Dissenter_Opens_In_Frame.js
+++ b/Dissenter_Opens_In_Frame.js
@@ -1,0 +1,1 @@
+javascript:(function(){var iframe=document.createElement('iframe');iframe.src='https://dissenter.com/discussion/begin?url='+encodeURIComponent(location.href);iframe.style.width="25%";iframe.style.height=window.innerHeight+'px';iframe.style.top="0";iframe.style.right="0";iframe.style.position="fixed";iframe.style.zIndex="9999";document.body.appendChild(iframe)})();


### PR DESCRIPTION
creates a frame 25% window width, loads dissenter comments in it

tested in pale moon on win7 laptop. not tested on android/iphone/ipad.
Lacks bells and whistles - doesn't have a close button.